### PR TITLE
Shared library/mrsw lock manager and collaborative editing

### DIFF
--- a/backend/src/main/java/com/boardwise/backend/BackendApplication.java
+++ b/backend/src/main/java/com/boardwise/backend/BackendApplication.java
@@ -2,8 +2,10 @@ package com.boardwise.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class BackendApplication {
 
 	public static void main(String[] args) {

--- a/backend/src/main/java/com/boardwise/backend/shared/config/LockExpiryScheduler.java
+++ b/backend/src/main/java/com/boardwise/backend/shared/config/LockExpiryScheduler.java
@@ -1,0 +1,35 @@
+package com.boardwise.backend.shared.config;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import com.boardwise.backend.vault.model.WriteLock;
+import com.boardwise.backend.vault.repository.WriteLockRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class LockExpiryScheduler {
+    private static final Logger log = LoggerFactory.getLogger(LockExpiryScheduler.class);
+    private final WriteLockRepository writeLockRepository;
+
+    @Scheduled(fixedRate = 10000) // runs every 10 seconds
+    public void expireStaleLocks(){
+        List<WriteLock> expiredLocks = writeLockRepository
+            .findByExpiresAtBefore(Instant.now()); // This is more efficient — MongoDB does the filtering instead of loading every lock document into memory.
+
+        if(!expiredLocks.isEmpty()){
+            writeLockRepository.deleteAll(expiredLocks);
+            expiredLocks.forEach(lock ->
+                log.info("Expired lock released - rulebookId: {}, heldBy: {}",
+                    lock.getRulebookId(), lock.getHeldByUserId())
+            );
+        }
+    }
+}

--- a/backend/src/main/java/com/boardwise/backend/shared/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/boardwise/backend/shared/exception/GlobalExceptionHandler.java
@@ -10,7 +10,9 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.NoHandlerFoundException;
 
 import com.boardwise.backend.vault.exception.LockConflictException;
+import com.boardwise.backend.vault.exception.LockNotHeldException;
 import com.boardwise.backend.vault.exception.RulebookNotFoundException;
+import com.boardwise.backend.vault.exception.VersionMismatchException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -39,6 +41,20 @@ public class GlobalExceptionHandler {
     public ResponseEntity<Map<String, String>> handleNoHandlerFound(NoHandlerFoundException ex) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
             .body(Map.of("error", "Endpoint not found: " + ex.getRequestURL()));
+    }
+
+    @ExceptionHandler(LockNotHeldException.class)
+    public ResponseEntity<Map<String, String>> handleLockNotHeld(
+        LockNotHeldException ex) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                .body(Map.of("error", ex.getMessage()));
+    }
+
+    @ExceptionHandler(VersionMismatchException.class)
+    public ResponseEntity<Map<String, String>> handleVersionMismatch(
+        VersionMismatchException ex) {
+            return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(Map.of("error", ex.getMessage()));
     }
 
     @ExceptionHandler(Exception.class)

--- a/backend/src/main/java/com/boardwise/backend/shared/security/JwtFilter.java
+++ b/backend/src/main/java/com/boardwise/backend/shared/security/JwtFilter.java
@@ -27,7 +27,8 @@ public class JwtFilter extends OncePerRequestFilter{
             String token = authHeader.substring(7);
             if(jwtUtil.validateToken(token)){
                 String username = jwtUtil.extractUsername(token);
-                UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(username, null, List.of());
+                UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
+                    username, token, List.of());
                 SecurityContextHolder.getContext().setAuthentication(auth);
             }
         }

--- a/backend/src/main/java/com/boardwise/backend/vault/controller/LockController.java
+++ b/backend/src/main/java/com/boardwise/backend/vault/controller/LockController.java
@@ -4,6 +4,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.boardwise.backend.shared.security.JwtUtil;
+import com.boardwise.backend.vault.dto.request.CommitDeltaRequestDto;
+import com.boardwise.backend.vault.dto.response.CommitDeltaResponseDto;
 import com.boardwise.backend.vault.dto.response.LockResponseDto;
 import com.boardwise.backend.vault.service.LockManagerService;
 
@@ -13,8 +15,10 @@ import org.bson.types.ObjectId;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 
 @RestController
@@ -47,6 +51,16 @@ public class LockController {
     }
 
     // AC-VLT-07: Commit Edit Delta
+    @PatchMapping("/{id}/text")
+    public ResponseEntity<CommitDeltaResponseDto> commitDelta(
+        @PathVariable String id,
+        @RequestBody CommitDeltaRequestDto request,
+        Authentication authentication){
+            ObjectId userId = extractUserId(authentication);
+            return ResponseEntity.ok(
+                lockManagerService.commitDelta(toObjectId(id), userId, request)
+            );
+    }
 
     // ----- private helpers -----
     private ObjectId extractUserId(Authentication authentication){

--- a/backend/src/main/java/com/boardwise/backend/vault/controller/LockController.java
+++ b/backend/src/main/java/com/boardwise/backend/vault/controller/LockController.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.bson.types.ObjectId;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 
@@ -34,8 +35,16 @@ public class LockController {
             lockManagerService.acquireLock(toObjectId(id), userId)
         );
     }
-        
+
     // AC-VLT-08: Release Write Lock
+    @DeleteMapping("/{id}/lock")
+    public ResponseEntity<Void> releaseLock(
+        @PathVariable String id,
+        Authentication authentication){
+            ObjectId userId = extractUserId(authentication);
+            lockManagerService.releaseLock(toObjectId(id), userId);
+            return ResponseEntity.ok().build();
+    }
 
     // AC-VLT-07: Commit Edit Delta
 

--- a/backend/src/main/java/com/boardwise/backend/vault/controller/LockController.java
+++ b/backend/src/main/java/com/boardwise/backend/vault/controller/LockController.java
@@ -1,5 +1,55 @@
 package com.boardwise.backend.vault.controller;
 
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.boardwise.backend.shared.security.JwtUtil;
+import com.boardwise.backend.vault.dto.response.LockResponseDto;
+import com.boardwise.backend.vault.service.LockManagerService;
+
+import lombok.RequiredArgsConstructor;
+
+import org.bson.types.ObjectId;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+
+
+@RestController
+@RequestMapping("/api/vault/rulebooks")
+@RequiredArgsConstructor
 public class LockController {
-    
+    private final LockManagerService lockManagerService;
+    private final JwtUtil jwtUtil;
+
+    // AC-VLT-06: Acquire Write Lock
+    @PostMapping("/{id}/lock")
+    public ResponseEntity<LockResponseDto> acquireLock(
+        @PathVariable String id,
+        Authentication authentication) {
+            ObjectId userId = extractUserId(authentication);
+        
+        return ResponseEntity.ok(
+            lockManagerService.acquireLock(toObjectId(id), userId)
+        );
+    }
+        
+    // AC-VLT-08: Release Write Lock
+
+    // AC-VLT-07: Commit Edit Delta
+
+    // ----- private helpers -----
+    private ObjectId extractUserId(Authentication authentication){
+        String token = (String) authentication.getCredentials();
+        return jwtUtil.extractUserId(token);
+    }
+
+    private ObjectId toObjectId(String id){
+        try {
+            return new ObjectId(id);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Invalid rulebook ID format: " + id);
+        }
+    }
 }

--- a/backend/src/main/java/com/boardwise/backend/vault/controller/LockController.java
+++ b/backend/src/main/java/com/boardwise/backend/vault/controller/LockController.java
@@ -1,0 +1,5 @@
+package com.boardwise.backend.vault.controller;
+
+public class LockController {
+    
+}

--- a/backend/src/main/java/com/boardwise/backend/vault/dto/request/CommitDeltaRequestDto.java
+++ b/backend/src/main/java/com/boardwise/backend/vault/dto/request/CommitDeltaRequestDto.java
@@ -1,0 +1,9 @@
+package com.boardwise.backend.vault.dto.request;
+
+import lombok.Data;
+
+@Data
+public class CommitDeltaRequestDto {
+    private int expectedVersion;
+    private String delta;
+}

--- a/backend/src/main/java/com/boardwise/backend/vault/dto/response/CommitDeltaResponseDto.java
+++ b/backend/src/main/java/com/boardwise/backend/vault/dto/response/CommitDeltaResponseDto.java
@@ -1,0 +1,14 @@
+package com.boardwise.backend.vault.dto.response;
+
+import java.time.Instant;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class CommitDeltaResponseDto {
+    private boolean committed;
+    private int newVersion;
+    private Instant committedAt;
+}

--- a/backend/src/main/java/com/boardwise/backend/vault/dto/response/LockResponseDto.java
+++ b/backend/src/main/java/com/boardwise/backend/vault/dto/response/LockResponseDto.java
@@ -1,0 +1,15 @@
+package com.boardwise.backend.vault.dto.response;
+
+import java.time.Instant;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class LockResponseDto {
+    private boolean lockGranted;
+    private String lockedBy;
+    private Instant expiresAt;
+    private int currentVersion;
+}

--- a/backend/src/main/java/com/boardwise/backend/vault/exception/LockNotHeldException.java
+++ b/backend/src/main/java/com/boardwise/backend/vault/exception/LockNotHeldException.java
@@ -1,0 +1,13 @@
+package com.boardwise.backend.vault.exception;
+
+import org.bson.types.ObjectId;
+
+public class LockNotHeldException extends RuntimeException {
+    public LockNotHeldException(ObjectId userId) {
+        super("User does not hold the write lock: " + userId);
+    }
+
+    public LockNotHeldException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/boardwise/backend/vault/exception/VersionMismatchException.java
+++ b/backend/src/main/java/com/boardwise/backend/vault/exception/VersionMismatchException.java
@@ -1,0 +1,7 @@
+package com.boardwise.backend.vault.exception;
+
+public class VersionMismatchException extends RuntimeException {
+    public VersionMismatchException(int expected, int actual) {
+        super("Version mismatch - expected: " + expected + ", actual: " + actual);
+    }
+}

--- a/backend/src/main/java/com/boardwise/backend/vault/repository/WriteLockRepository.java
+++ b/backend/src/main/java/com/boardwise/backend/vault/repository/WriteLockRepository.java
@@ -1,5 +1,7 @@
 package com.boardwise.backend.vault.repository;
 
+import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 
 import org.bson.types.ObjectId;
@@ -11,4 +13,6 @@ import com.boardwise.backend.vault.model.WriteLock;
 @Repository
 public interface WriteLockRepository extends MongoRepository<WriteLock, ObjectId> {
     Optional<WriteLock> findByRulebookId(ObjectId rulebookId);
+
+    List<WriteLock> findByExpiresAtBefore(Instant now);
 }

--- a/backend/src/main/java/com/boardwise/backend/vault/service/LockManagerService.java
+++ b/backend/src/main/java/com/boardwise/backend/vault/service/LockManagerService.java
@@ -80,7 +80,7 @@ public class LockManagerService {
 
     // AC-VLT-07: Commit Edit Delta
     public CommitDeltaResponseDto commitDelta(ObjectId rulebookId, ObjectId userId, CommitDeltaRequestDto request){
-        findRulebookOrThrow(rulebookId);
+        Rulebook rulebook = findRulebookOrThrow(rulebookId);
 
         // Verify that the caller holds the lock
         WriteLock lock = writeLockRepository.findByRulebookId(rulebookId)
@@ -108,7 +108,6 @@ public class LockManagerService {
         rulebookTextRepository.save(text);
 
         // Update rulebook version
-        Rulebook rulebook = findRulebookOrThrow(rulebookId);
         rulebook.setVersion(newVersion);
         rulebook.setUpdatedAt(now);
         rulebookRepository.save(rulebook);

--- a/backend/src/main/java/com/boardwise/backend/vault/service/LockManagerService.java
+++ b/backend/src/main/java/com/boardwise/backend/vault/service/LockManagerService.java
@@ -1,5 +1,66 @@
 package com.boardwise.backend.vault.service;
 
+import java.time.Instant;
+
+import org.bson.types.ObjectId;
+import org.springframework.stereotype.Service;
+
+import com.boardwise.backend.vault.dto.response.LockResponseDto;
+import com.boardwise.backend.vault.exception.LockConflictException;
+import com.boardwise.backend.vault.exception.RulebookNotFoundException;
+import com.boardwise.backend.vault.model.Rulebook;
+import com.boardwise.backend.vault.model.WriteLock;
+import com.boardwise.backend.vault.repository.RulebookRepository;
+import com.boardwise.backend.vault.repository.WriteLockRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
 public class LockManagerService {
+    private static final int LOCK_EXPIRY_SECONDS = 30;
+
+    private final WriteLockRepository writeLockRepository;
+    private final RulebookRepository rulebookRepository;
     
+    // AC-VLT-06: Acquire Write Lock
+    public LockResponseDto acquireLock(ObjectId rulebookId, ObjectId userId){
+        Rulebook rulebook = findRulebookOrThrow(rulebookId);
+
+        writeLockRepository.findByRulebookId(rulebookId).ifPresent(existingLock -> {
+            // Check if the lock has expired
+            if(existingLock.getExpiresAt().isAfter(Instant.now())){
+                throw new LockConflictException(rulebookId);
+            }
+            // expired lock - clear it before granting a new one
+            writeLockRepository.delete(existingLock);
+        });
+
+        Instant now = Instant.now();
+        WriteLock lock = WriteLock.builder()
+            .rulebookId(rulebookId)
+            .heldByUserId(userId)
+            .acquiredAt(now)
+            .expiresAt(now.plusSeconds(LOCK_EXPIRY_SECONDS))
+            .build();
+
+        writeLockRepository.save(lock);
+
+        return LockResponseDto.builder()
+            .lockGranted(true)
+            .lockedBy(userId.toHexString())
+            .expiresAt(lock.getExpiresAt())
+            .currentVersion(rulebook.getVersion())
+            .build();
+    }
+
+    // AC-VLT-08: Release Write Lock
+    
+    // AC-VLT-07: Commit Edit Delta
+
+    // --- private helpers ---
+    private Rulebook findRulebookOrThrow(ObjectId id){
+        return rulebookRepository.findById(id)
+            .orElseThrow(() -> new RulebookNotFoundException(id));
+    }
 }

--- a/backend/src/main/java/com/boardwise/backend/vault/service/LockManagerService.java
+++ b/backend/src/main/java/com/boardwise/backend/vault/service/LockManagerService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 
 import com.boardwise.backend.vault.dto.response.LockResponseDto;
 import com.boardwise.backend.vault.exception.LockConflictException;
+import com.boardwise.backend.vault.exception.LockNotHeldException;
 import com.boardwise.backend.vault.exception.RulebookNotFoundException;
 import com.boardwise.backend.vault.model.Rulebook;
 import com.boardwise.backend.vault.model.WriteLock;
@@ -55,7 +56,19 @@ public class LockManagerService {
     }
 
     // AC-VLT-08: Release Write Lock
-    
+    public void releaseLock(ObjectId rulebookId, ObjectId userId) {
+        findRulebookOrThrow(rulebookId);
+
+        WriteLock lock = writeLockRepository.findByRulebookId(rulebookId)
+            .orElseThrow(() -> new LockNotHeldException(userId));
+
+        if(!lock.getHeldByUserId().equals(userId)){
+            throw new LockNotHeldException(userId);
+        }
+
+        writeLockRepository.delete(lock);
+    }
+
     // AC-VLT-07: Commit Edit Delta
 
     // --- private helpers ---

--- a/backend/src/main/java/com/boardwise/backend/vault/service/LockManagerService.java
+++ b/backend/src/main/java/com/boardwise/backend/vault/service/LockManagerService.java
@@ -5,13 +5,20 @@ import java.time.Instant;
 import org.bson.types.ObjectId;
 import org.springframework.stereotype.Service;
 
+import com.boardwise.backend.vault.dto.request.CommitDeltaRequestDto;
+import com.boardwise.backend.vault.dto.response.CommitDeltaResponseDto;
 import com.boardwise.backend.vault.dto.response.LockResponseDto;
 import com.boardwise.backend.vault.exception.LockConflictException;
 import com.boardwise.backend.vault.exception.LockNotHeldException;
 import com.boardwise.backend.vault.exception.RulebookNotFoundException;
+import com.boardwise.backend.vault.exception.VersionMismatchException;
+import com.boardwise.backend.vault.model.EditEvent;
 import com.boardwise.backend.vault.model.Rulebook;
+import com.boardwise.backend.vault.model.RulebookText;
 import com.boardwise.backend.vault.model.WriteLock;
+import com.boardwise.backend.vault.repository.EditEventRepository;
 import com.boardwise.backend.vault.repository.RulebookRepository;
+import com.boardwise.backend.vault.repository.RulebookTextRepository;
 import com.boardwise.backend.vault.repository.WriteLockRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -23,6 +30,8 @@ public class LockManagerService {
 
     private final WriteLockRepository writeLockRepository;
     private final RulebookRepository rulebookRepository;
+    private final RulebookTextRepository rulebookTextRepository;
+    private final EditEventRepository editEventRepository;
     
     // AC-VLT-06: Acquire Write Lock
     public LockResponseDto acquireLock(ObjectId rulebookId, ObjectId userId){
@@ -70,7 +79,60 @@ public class LockManagerService {
     }
 
     // AC-VLT-07: Commit Edit Delta
+    public CommitDeltaResponseDto commitDelta(ObjectId rulebookId, ObjectId userId, CommitDeltaRequestDto request){
+        findRulebookOrThrow(rulebookId);
 
+        // Verify that the caller holds the lock
+        WriteLock lock = writeLockRepository.findByRulebookId(rulebookId)
+            .orElseThrow(() -> new LockNotHeldException(userId));
+
+        if(!lock.getHeldByUserId().equals(userId)){
+            throw new LockNotHeldException(userId);
+        }
+
+        // Verify version matches
+        RulebookText text = rulebookTextRepository.findByRulebookId(rulebookId)
+            .orElseThrow(() -> new RulebookNotFoundException(rulebookId));
+
+        if(text.getVersion() != request.getExpectedVersion()){
+            throw new VersionMismatchException(request.getExpectedVersion(), text.getVersion());
+        }
+
+        // Commit delta
+        Instant now = Instant.now();
+        int newVersion = text.getVersion() + 1;
+
+        text.setContent(request.getDelta());
+        text.setVersion(newVersion);
+        text.setUpdatedAt(now);
+        rulebookTextRepository.save(text);
+
+        // Update rulebook version
+        Rulebook rulebook = findRulebookOrThrow(rulebookId);
+        rulebook.setVersion(newVersion);
+        rulebook.setUpdatedAt(now);
+        rulebookRepository.save(rulebook);
+
+        // Append edit event
+        EditEvent event = EditEvent.builder()
+            .rulebookId(rulebookId)
+            .editorId(userId)
+            .delta(request.getDelta())
+            .versionAfter(newVersion)
+            .committedAt(now)
+            .build();
+        editEventRepository.save(event);
+
+        // refresh lock expiry on activity
+        lock.setExpiresAt(now.plusSeconds(LOCK_EXPIRY_SECONDS));
+        writeLockRepository.save(lock);
+
+        return CommitDeltaResponseDto.builder()
+            .committed(true)
+            .newVersion(newVersion)
+            .committedAt(now)
+            .build();
+    }
     // --- private helpers ---
     private Rulebook findRulebookOrThrow(ObjectId id){
         return rulebookRepository.findById(id)

--- a/backend/src/test/java/com/boardwise/backend/LockControllerTest.java
+++ b/backend/src/test/java/com/boardwise/backend/LockControllerTest.java
@@ -1,0 +1,278 @@
+package com.boardwise.backend;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import java.time.Instant;
+
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.boardwise.backend.shared.exception.GlobalExceptionHandler;
+import com.boardwise.backend.shared.security.JwtUtil;
+import com.boardwise.backend.vault.controller.LockController;
+import com.boardwise.backend.vault.dto.response.CommitDeltaResponseDto;
+import com.boardwise.backend.vault.dto.response.LockResponseDto;
+import com.boardwise.backend.vault.exception.LockConflictException;
+import com.boardwise.backend.vault.exception.LockNotHeldException;
+import com.boardwise.backend.vault.exception.RulebookNotFoundException;
+import com.boardwise.backend.vault.exception.VersionMismatchException;
+import com.boardwise.backend.vault.service.LockManagerService;
+
+@WebMvcTest(LockController.class)
+@Import(GlobalExceptionHandler.class)
+public class LockControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private LockManagerService lockManagerService;
+
+    @MockitoBean
+    private JwtUtil jwtUtil;
+
+    private ObjectId rulebookId;
+    private ObjectId userId;
+    private LockResponseDto mockLockResponse;
+    private CommitDeltaResponseDto mockCommitDeltaResponse;
+
+    @BeforeEach
+    void setUp() {
+        rulebookId = new ObjectId();
+        userId = new ObjectId();
+
+        mockLockResponse = LockResponseDto.builder()
+                .lockGranted(true)
+                .lockedBy(userId.toHexString())
+                .expiresAt(Instant.now().plusSeconds(30))
+                .currentVersion(3)
+                .build();
+
+        mockCommitDeltaResponse = CommitDeltaResponseDto.builder()
+                .committed(true)
+                .newVersion(4)
+                .committedAt(Instant.now())
+                .build();
+
+        // default behaviour — extractUserId returns a consistent userId
+        when(jwtUtil.extractUserId(any())).thenReturn(userId);
+    }
+
+    // --- POST /api/vault/rulebooks/{id}/lock ---
+
+    @Test
+    @WithMockUser
+    void acquireLock_returns200WhenGranted() throws Exception {
+        when(lockManagerService.acquireLock(any(ObjectId.class), any(ObjectId.class)))
+                .thenReturn(mockLockResponse);
+
+        mockMvc.perform(post("/api/vault/rulebooks/{id}/lock",
+                rulebookId.toHexString())
+                .with(csrf())) // Used to bypass CSRF protection in the test
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.lockGranted").value(true))
+                .andExpect(jsonPath("$.lockedBy").value(userId.toHexString()))
+                .andExpect(jsonPath("$.currentVersion").value(3));
+    }
+
+    @Test
+    @WithMockUser
+    void acquireLock_returns409WhenLockAlreadyHeld() throws Exception {
+        when(lockManagerService.acquireLock(any(ObjectId.class), any(ObjectId.class)))
+                .thenThrow(new LockConflictException(rulebookId));
+
+        mockMvc.perform(post("/api/vault/rulebooks/{id}/lock",
+                rulebookId.toHexString())
+                .with(csrf())) // Used to bypass CSRF protection in the test
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error").exists());
+    }
+
+    @Test
+    @WithMockUser
+    void acquireLock_returns404WhenRulebookNotFound() throws Exception {
+        when(lockManagerService.acquireLock(any(ObjectId.class), any(ObjectId.class)))
+                .thenThrow(new RulebookNotFoundException(rulebookId));
+
+        mockMvc.perform(post("/api/vault/rulebooks/{id}/lock",
+                rulebookId.toHexString())
+                .with(csrf())) // Used to bypass CSRF protection in the test
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error").exists());
+    }
+
+    @Test
+    @WithMockUser
+    void acquireLock_returns400ForMalformedId() throws Exception {
+        mockMvc.perform(post("/api/vault/rulebooks/{id}/lock", "not-a-valid-id")
+        .with(csrf())) // Used to bypass CSRF protection in the test
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").exists());
+    }
+
+    // --- DELETE /api/vault/rulebooks/{id}/lock ---
+
+    @Test
+    @WithMockUser
+    void releaseLock_returns200WhenReleased() throws Exception {
+        doNothing().when(lockManagerService)
+                .releaseLock(any(ObjectId.class), any(ObjectId.class));
+
+        mockMvc.perform(delete("/api/vault/rulebooks/{id}/lock",
+                rulebookId.toHexString())
+                .with(csrf())) // Used to bypass CSRF protection in the test
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser
+    void releaseLock_returns403WhenCallerIsNotLockHolder() throws Exception {
+        doThrow(new LockNotHeldException(userId))
+                .when(lockManagerService)
+                .releaseLock(any(ObjectId.class), any(ObjectId.class));
+
+        mockMvc.perform(delete("/api/vault/rulebooks/{id}/lock",
+                rulebookId.toHexString())
+                .with(csrf())) // Used to bypass CSRF protection in the test
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.error").exists());
+    }
+
+    @Test
+    @WithMockUser
+    void releaseLock_returns404WhenRulebookNotFound() throws Exception {
+        doThrow(new RulebookNotFoundException(rulebookId))
+                .when(lockManagerService)
+                .releaseLock(any(ObjectId.class), any(ObjectId.class));
+
+        mockMvc.perform(delete("/api/vault/rulebooks/{id}/lock",
+                rulebookId.toHexString())
+                .with(csrf())) // Used to bypass CSRF protection in the test
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error").exists());
+    }
+
+    @Test
+    @WithMockUser
+    void releaseLock_returns400ForMalformedId() throws Exception {
+        mockMvc.perform(delete("/api/vault/rulebooks/{id}/lock", "not-a-valid-id")
+        .with(csrf())) // Used to bypass CSRF protection in the test
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").exists());
+    }
+
+    // --- PATCH /api/vault/rulebooks/{id}/text ---
+
+    @Test
+    @WithMockUser
+    void commitDelta_returns200WhenCommitted() throws Exception {
+        when(lockManagerService.commitDelta(
+                any(ObjectId.class), any(ObjectId.class), any()))
+                .thenReturn(mockCommitDeltaResponse);
+
+        mockMvc.perform(patch("/api/vault/rulebooks/{id}/text",
+                rulebookId.toHexString())
+                .with(csrf()) // Used to bypass CSRF protection in the test
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                            {
+                                "expectedVersion": 3,
+                                "delta": "Updated content."
+                            }
+                        """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.committed").value(true))
+                .andExpect(jsonPath("$.newVersion").value(4));
+    }
+
+    @Test
+    @WithMockUser
+    void commitDelta_returns403WhenCallerIsNotLockHolder() throws Exception {
+        when(lockManagerService.commitDelta(
+                any(ObjectId.class), any(ObjectId.class), any()))
+                .thenThrow(new LockNotHeldException(userId));
+
+        mockMvc.perform(patch("/api/vault/rulebooks/{id}/text",
+                rulebookId.toHexString())
+                .with(csrf()) // Used to bypass CSRF protection in the test
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                            {
+                                "expectedVersion": 3,
+                                "delta": "Updated content."
+                            }
+                        """))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.error").exists());
+    }
+
+    @Test
+    @WithMockUser
+    void commitDelta_returns409OnVersionMismatch() throws Exception {
+        when(lockManagerService.commitDelta(
+                any(ObjectId.class), any(ObjectId.class), any()))
+                .thenThrow(new VersionMismatchException(1, 3));
+
+        mockMvc.perform(patch("/api/vault/rulebooks/{id}/text",
+                rulebookId.toHexString())
+                .with(csrf()) // Used to bypass CSRF protection in the test
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                            {
+                                "expectedVersion": 1,
+                                "delta": "Updated content."
+                            }
+                        """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error").exists());
+    }
+
+    @Test
+    @WithMockUser
+    void commitDelta_returns404WhenRulebookNotFound() throws Exception {
+        when(lockManagerService.commitDelta(
+                any(ObjectId.class), any(ObjectId.class), any()))
+                .thenThrow(new RulebookNotFoundException(rulebookId));
+
+        mockMvc.perform(patch("/api/vault/rulebooks/{id}/text",
+                rulebookId.toHexString())
+                .with(csrf()) // Used to bypass CSRF protection in the test
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                            {
+                                "expectedVersion": 3,
+                                "delta": "Updated content."
+                            }
+                        """))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error").exists());
+    }
+
+    @Test
+    @WithMockUser
+    void commitDelta_returns400ForMalformedId() throws Exception {
+        mockMvc.perform(patch("/api/vault/rulebooks/{id}/text", "not-a-valid-id")
+        .with(csrf()) // Used to bypass CSRF protection in the test
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                            {
+                                "expectedVersion": 3,
+                                "delta": "Updated content."
+                            }
+                        """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").exists());
+    }
+}

--- a/backend/src/test/java/com/boardwise/backend/LockManagerServiceTest.java
+++ b/backend/src/test/java/com/boardwise/backend/LockManagerServiceTest.java
@@ -1,0 +1,338 @@
+package com.boardwise.backend;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.boardwise.backend.vault.dto.request.CommitDeltaRequestDto;
+import com.boardwise.backend.vault.dto.response.CommitDeltaResponseDto;
+import com.boardwise.backend.vault.dto.response.LockResponseDto;
+import com.boardwise.backend.vault.exception.LockConflictException;
+import com.boardwise.backend.vault.exception.LockNotHeldException;
+import com.boardwise.backend.vault.exception.RulebookNotFoundException;
+import com.boardwise.backend.vault.exception.VersionMismatchException;
+import com.boardwise.backend.vault.model.EditEvent;
+import com.boardwise.backend.vault.model.Rulebook;
+import com.boardwise.backend.vault.model.RulebookText;
+import com.boardwise.backend.vault.model.WriteLock;
+import com.boardwise.backend.vault.repository.EditEventRepository;
+import com.boardwise.backend.vault.repository.RulebookRepository;
+import com.boardwise.backend.vault.repository.RulebookTextRepository;
+import com.boardwise.backend.vault.repository.WriteLockRepository;
+import com.boardwise.backend.vault.service.LockManagerService;
+
+@ExtendWith(MockitoExtension.class)
+public class LockManagerServiceTest {
+
+    @Mock
+    private WriteLockRepository writeLockRepository;
+    @Mock
+    private RulebookRepository rulebookRepository;
+    @Mock
+    private RulebookTextRepository rulebookTextRepository;
+    @Mock
+    private EditEventRepository editEventRepository;
+
+    @InjectMocks
+    private LockManagerService lockManagerService;
+
+    private ObjectId rulebookId;
+    private ObjectId userId;
+    private ObjectId otherUserId;
+    private Rulebook mockRulebook;
+    private RulebookText mockRulebookText;
+    private WriteLock activeLock;
+    private WriteLock expiredLock;
+
+    @BeforeEach
+    void setUp() {
+        rulebookId = new ObjectId();
+        userId = new ObjectId();
+        otherUserId = new ObjectId();
+
+        mockRulebook = Rulebook.builder()
+                .id(rulebookId)
+                .gameName("Catan")
+                .edition("3rd Edition")
+                .status("Ready")
+                .version(3)
+                .contributorId(new ObjectId())
+                .r2PdfKey("rulebooks/catan.pdf")
+                .uploadedAt(Instant.now())
+                .updatedAt(Instant.now())
+                .build();
+
+        mockRulebookText = RulebookText.builder()
+                .id(new ObjectId())
+                .rulebookId(rulebookId)
+                .content("Original content.")
+                .version(3)
+                .updatedAt(Instant.now())
+                .build();
+
+        activeLock = WriteLock.builder()
+                .id(new ObjectId())
+                .rulebookId(rulebookId)
+                .heldByUserId(userId)
+                .acquiredAt(Instant.now())
+                .expiresAt(Instant.now().plusSeconds(30))
+                .build();
+
+        expiredLock = WriteLock.builder()
+                .id(new ObjectId())
+                .rulebookId(rulebookId)
+                .heldByUserId(otherUserId)
+                .acquiredAt(Instant.now().minusSeconds(60))
+                .expiresAt(Instant.now().minusSeconds(30))
+                .build();
+    }
+
+    // --- acquireLock ---
+
+    @Test
+    void acquireLock_grantsLockWhenNoneHeld() {
+        when(rulebookRepository.findById(rulebookId))
+                .thenReturn(Optional.of(mockRulebook));
+        when(writeLockRepository.findByRulebookId(rulebookId))
+                .thenReturn(Optional.empty());
+        when(writeLockRepository.save(any(WriteLock.class)))
+                .thenAnswer(i -> i.getArgument(0));
+
+        LockResponseDto result = lockManagerService.acquireLock(rulebookId, userId);
+
+        assertTrue(result.isLockGranted());
+        assertEquals(userId.toHexString(), result.getLockedBy());
+        assertNotNull(result.getExpiresAt());
+        assertEquals(3, result.getCurrentVersion());
+        verify(writeLockRepository).save(any(WriteLock.class));
+    }
+
+    @Test
+    void acquireLock_throwsConflictWhenActiveLockExists() {
+        when(rulebookRepository.findById(rulebookId))
+                .thenReturn(Optional.of(mockRulebook));
+        when(writeLockRepository.findByRulebookId(rulebookId))
+                .thenReturn(Optional.of(activeLock));
+
+        assertThrows(LockConflictException.class,
+                () -> lockManagerService.acquireLock(rulebookId, userId));
+
+        verify(writeLockRepository, never()).save(any());
+    }
+
+    @Test
+    void acquireLock_clearsExpiredLockAndGrantsNew() {
+        when(rulebookRepository.findById(rulebookId))
+                .thenReturn(Optional.of(mockRulebook));
+        when(writeLockRepository.findByRulebookId(rulebookId))
+                .thenReturn(Optional.of(expiredLock));
+        when(writeLockRepository.save(any(WriteLock.class)))
+                .thenAnswer(i -> i.getArgument(0));
+
+        LockResponseDto result = lockManagerService.acquireLock(rulebookId, userId);
+
+        assertTrue(result.isLockGranted());
+        verify(writeLockRepository).delete(expiredLock);
+        verify(writeLockRepository).save(any(WriteLock.class));
+    }
+
+    @Test
+    void acquireLock_throwsNotFoundForUnknownRulebook() {
+        when(rulebookRepository.findById(rulebookId))
+                .thenReturn(Optional.empty());
+
+        assertThrows(RulebookNotFoundException.class,
+                () -> lockManagerService.acquireLock(rulebookId, userId));
+    }
+
+    // --- releaseLock ---
+
+    @Test
+    void releaseLock_successfullyReleasesLock() {
+        when(rulebookRepository.findById(rulebookId))
+                .thenReturn(Optional.of(mockRulebook));
+        when(writeLockRepository.findByRulebookId(rulebookId))
+                .thenReturn(Optional.of(activeLock));
+
+        lockManagerService.releaseLock(rulebookId, userId);
+
+        verify(writeLockRepository).delete(activeLock);
+    }
+
+    @Test
+    void releaseLock_throwsForbiddenWhenCallerIsNotLockHolder() {
+        when(rulebookRepository.findById(rulebookId))
+                .thenReturn(Optional.of(mockRulebook));
+        when(writeLockRepository.findByRulebookId(rulebookId))
+                .thenReturn(Optional.of(activeLock));
+
+        assertThrows(LockNotHeldException.class,
+                () -> lockManagerService.releaseLock(rulebookId, otherUserId));
+
+        verify(writeLockRepository, never()).delete(any());
+    }
+
+    @Test
+    void releaseLock_throwsForbiddenWhenNoLockExists() {
+        when(rulebookRepository.findById(rulebookId))
+                .thenReturn(Optional.of(mockRulebook));
+        when(writeLockRepository.findByRulebookId(rulebookId))
+                .thenReturn(Optional.empty());
+
+        assertThrows(LockNotHeldException.class,
+                () -> lockManagerService.releaseLock(rulebookId, userId));
+    }
+
+    @Test
+    void releaseLock_throwsNotFoundForUnknownRulebook() {
+        when(rulebookRepository.findById(rulebookId))
+                .thenReturn(Optional.empty());
+
+        assertThrows(RulebookNotFoundException.class,
+                () -> lockManagerService.releaseLock(rulebookId, userId));
+    }
+
+    // --- commitDelta ---
+
+    @Test
+    void commitDelta_successfullyCommitsDelta() {
+        CommitDeltaRequestDto request = new CommitDeltaRequestDto();
+        request.setExpectedVersion(3);
+        request.setDelta("Updated content.");
+
+        when(rulebookRepository.findById(rulebookId))
+                .thenReturn(Optional.of(mockRulebook));
+        when(writeLockRepository.findByRulebookId(rulebookId))
+                .thenReturn(Optional.of(activeLock));
+        when(rulebookTextRepository.findByRulebookId(rulebookId))
+                .thenReturn(Optional.of(mockRulebookText));
+        when(rulebookTextRepository.save(any(RulebookText.class)))
+                .thenAnswer(i -> i.getArgument(0));
+        when(rulebookRepository.save(any(Rulebook.class)))
+                .thenAnswer(i -> i.getArgument(0));
+        when(editEventRepository.save(any(EditEvent.class)))
+                .thenAnswer(i -> i.getArgument(0));
+        when(writeLockRepository.save(any(WriteLock.class)))
+                .thenAnswer(i -> i.getArgument(0));
+
+        CommitDeltaResponseDto result = lockManagerService.commitDelta(
+                rulebookId, userId, request);
+
+        assertTrue(result.isCommitted());
+        assertEquals(4, result.getNewVersion());
+        assertNotNull(result.getCommittedAt());
+        verify(rulebookTextRepository).save(any(RulebookText.class));
+        verify(rulebookRepository).save(any(Rulebook.class));
+        verify(editEventRepository).save(any(EditEvent.class));
+        verify(writeLockRepository).save(any(WriteLock.class));
+    }
+
+    @Test
+    void commitDelta_throwsForbiddenWhenCallerIsNotLockHolder() {
+        CommitDeltaRequestDto request = new CommitDeltaRequestDto();
+        request.setExpectedVersion(3);
+        request.setDelta("Updated content.");
+
+        when(rulebookRepository.findById(rulebookId))
+                .thenReturn(Optional.of(mockRulebook));
+        when(writeLockRepository.findByRulebookId(rulebookId))
+                .thenReturn(Optional.of(activeLock));
+
+        assertThrows(LockNotHeldException.class,
+                () -> lockManagerService.commitDelta(rulebookId, otherUserId, request));
+
+        verify(rulebookTextRepository, never()).save(any());
+        verify(editEventRepository, never()).save(any());
+    }
+
+    @Test
+    void commitDelta_throwsForbiddenWhenNoLockHeld() {
+        CommitDeltaRequestDto request = new CommitDeltaRequestDto();
+        request.setExpectedVersion(3);
+        request.setDelta("Updated content.");
+
+        when(rulebookRepository.findById(rulebookId))
+                .thenReturn(Optional.of(mockRulebook));
+        when(writeLockRepository.findByRulebookId(rulebookId))
+                .thenReturn(Optional.empty());
+
+        assertThrows(LockNotHeldException.class,
+                () -> lockManagerService.commitDelta(rulebookId, userId, request));
+
+        verify(rulebookTextRepository, never()).save(any());
+        verify(editEventRepository, never()).save(any());
+    }
+
+    @Test
+    void commitDelta_throwsConflictOnVersionMismatch() {
+        CommitDeltaRequestDto request = new CommitDeltaRequestDto();
+        request.setExpectedVersion(1);
+        request.setDelta("Updated content.");
+
+        when(rulebookRepository.findById(rulebookId))
+                .thenReturn(Optional.of(mockRulebook));
+        when(writeLockRepository.findByRulebookId(rulebookId))
+                .thenReturn(Optional.of(activeLock));
+        when(rulebookTextRepository.findByRulebookId(rulebookId))
+                .thenReturn(Optional.of(mockRulebookText));
+
+        assertThrows(VersionMismatchException.class,
+                () -> lockManagerService.commitDelta(rulebookId, userId, request));
+
+        verify(rulebookTextRepository, never()).save(any());
+        verify(editEventRepository, never()).save(any());
+    }
+
+    @Test
+    void commitDelta_throwsNotFoundWhenRulebookMissing() {
+        CommitDeltaRequestDto request = new CommitDeltaRequestDto();
+        request.setExpectedVersion(3);
+        request.setDelta("Updated content.");
+
+        when(rulebookRepository.findById(rulebookId))
+                .thenReturn(Optional.empty());
+
+        assertThrows(RulebookNotFoundException.class,
+                () -> lockManagerService.commitDelta(rulebookId, userId, request));
+    }
+
+    @Test
+    void commitDelta_refreshesLockExpiryOnSuccess() {
+        CommitDeltaRequestDto request = new CommitDeltaRequestDto();
+        request.setExpectedVersion(3);
+        request.setDelta("Updated content.");
+
+        Instant beforeCommit = Instant.now();
+
+        when(rulebookRepository.findById(rulebookId))
+                .thenReturn(Optional.of(mockRulebook));
+        when(writeLockRepository.findByRulebookId(rulebookId))
+                .thenReturn(Optional.of(activeLock));
+        when(rulebookTextRepository.findByRulebookId(rulebookId))
+                .thenReturn(Optional.of(mockRulebookText));
+        when(rulebookTextRepository.save(any(RulebookText.class)))
+                .thenAnswer(i -> i.getArgument(0));
+        when(rulebookRepository.save(any(Rulebook.class)))
+                .thenAnswer(i -> i.getArgument(0));
+        when(editEventRepository.save(any(EditEvent.class)))
+                .thenAnswer(i -> i.getArgument(0));
+        when(writeLockRepository.save(any(WriteLock.class)))
+                .thenAnswer(i -> i.getArgument(0));
+
+        lockManagerService.commitDelta(rulebookId, userId, request);
+
+        assertTrue(activeLock.getExpiresAt().isAfter(beforeCommit.plusSeconds(29)));
+        verify(writeLockRepository, times(1)).save(activeLock);
+    }
+}


### PR DESCRIPTION
### Phase 4 — MRSW Lock Manager & Collaborative Editing (Spring Boot)

Implemented the concurrency control layer and edit commit flow.

- Implemented `POST /api/vault/rulebooks/{id}/lock` — acquire write lock, reject with 409 if already held
- Implemented `DELETE /api/vault/rulebooks/{id}/lock` — voluntary lock release
- Implemented idle lock expiry (30-second timeout, scheduled task or TTL index)
- Implemented `PATCH /api/vault/rulebooks/{id}/text` — validate lock ownership, optimistic version check, commit delta, increment version, append `EDIT_EVENT`